### PR TITLE
调整几个函数的参数，以适应新版本的fgsea

### DIFF
--- a/R/enricher.R
+++ b/R/enricher.R
@@ -41,9 +41,9 @@ enricher <- function(gene,
 ##' @title GSEA
 ##' @param geneList order ranked geneList
 ##' @param exponent weight of each step
-##' @param nPerm number of permutations
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
+##' @param eps_dose This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue cutoff
 ##' @param pAdjustMethod p value adjustment method
 ##' @param TERM2GENE user input annotation of TERM TO GENE mapping, a data.frame of 2 column with term and gene
@@ -56,9 +56,10 @@ enricher <- function(gene,
 ##' @export
 GSEA <- function(geneList,
                  exponent = 1,
-                 nPerm = 1000,
+                 #nPerm = 1000,
                  minGSSize = 10,
                  maxGSSize = 500,
+                 eps_dose  = 1e-10,
                  pvalueCutoff = 0.05,
                  pAdjustMethod = "BH",
                  TERM2GENE,
@@ -71,9 +72,10 @@ GSEA <- function(geneList,
 
     GSEA_internal(geneList = geneList,
                   exponent = exponent,
-                  nPerm = nPerm,
+                  #nPerm = nPerm,
                   minGSSize = minGSSize,
                   maxGSSize = maxGSSize,
+                  eps_dose = eps_dose,
                   pvalueCutoff = pvalueCutoff,
                   pAdjustMethod = pAdjustMethod,
                   verbose = verbose,

--- a/R/enricher.R
+++ b/R/enricher.R
@@ -41,7 +41,6 @@ enricher <- function(gene,
 ##' @title GSEA
 ##' @param geneList order ranked geneList
 ##' @param exponent weight of each step
-##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
 ##' @param eps This parameter sets the boundary for calculating the p value.
@@ -52,12 +51,12 @@ enricher <- function(gene,
 ##' @param verbose logical
 ##' @param seed logical
 ##' @param by one of 'fgsea' or 'DOSE'
+##' @param ... other parameter
 ##' @return gseaResult object
 ##' @author Guangchuang Yu
 ##' @export
 GSEA <- function(geneList,
                  exponent = 1,
-                 nPerm = 1000,
                  minGSSize = 10,
                  maxGSSize = 500,
                  eps  = 1e-10,
@@ -67,35 +66,23 @@ GSEA <- function(geneList,
                  TERM2NAME = NA,
                  verbose = TRUE,
                  seed = FALSE,
-                 by = 'fgsea') {
+                 by = 'fgsea',
+                 ...) {
 
     USER_DATA <- build_Anno(TERM2GENE, TERM2NAME)
-    
-    if(missing(nPerm)) {
-        GSEA_internal(geneList      = geneList,
-                      exponent      = exponent,
-                      minGSSize     = minGSSize,
-                      maxGSSize     = maxGSSize,
-                      eps           = eps,
-                      pvalueCutoff  = pvalueCutoff,
-                      pAdjustMethod = pAdjustMethod,
-                      verbose       = verbose,
-                      USER_DATA     = USER_DATA,
-                      seed          = seed,
-                      by            = by)
-    } else {
-        GSEA_internal(geneList      = geneList,
-                      exponent      = exponent,
-                      nPerm         = nPerm,
-                      minGSSize     = minGSSize,
-                      maxGSSize     = maxGSSize,
-                      pvalueCutoff  = pvalueCutoff,
-                      pAdjustMethod = pAdjustMethod,
-                      verbose       = verbose,
-                      USER_DATA     = USER_DATA,
-                      seed          = seed,
-                      by            = by)
-    }
+
+    GSEA_internal(geneList      = geneList,
+                  exponent      = exponent,
+                  minGSSize     = minGSSize,
+                  maxGSSize     = maxGSSize,
+                  eps           = eps,
+                  pvalueCutoff  = pvalueCutoff,
+                  pAdjustMethod = pAdjustMethod,
+                  verbose       = verbose,
+                  USER_DATA     = USER_DATA,
+                  seed          = seed,
+                  by            = by,
+                  ...)
     
 }
 

--- a/R/enricher.R
+++ b/R/enricher.R
@@ -41,9 +41,10 @@ enricher <- function(gene,
 ##' @title GSEA
 ##' @param geneList order ranked geneList
 ##' @param exponent weight of each step
+##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
-##' @param eps_dose This parameter sets the boundary for calculating the p value.
+##' @param eps This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue cutoff
 ##' @param pAdjustMethod p value adjustment method
 ##' @param TERM2GENE user input annotation of TERM TO GENE mapping, a data.frame of 2 column with term and gene
@@ -56,10 +57,10 @@ enricher <- function(gene,
 ##' @export
 GSEA <- function(geneList,
                  exponent = 1,
-                 #nPerm = 1000,
+                 nPerm = 1000,
                  minGSSize = 10,
                  maxGSSize = 500,
-                 eps_dose  = 1e-10,
+                 eps  = 1e-10,
                  pvalueCutoff = 0.05,
                  pAdjustMethod = "BH",
                  TERM2GENE,
@@ -69,18 +70,32 @@ GSEA <- function(geneList,
                  by = 'fgsea') {
 
     USER_DATA <- build_Anno(TERM2GENE, TERM2NAME)
-
-    GSEA_internal(geneList = geneList,
-                  exponent = exponent,
-                  #nPerm = nPerm,
-                  minGSSize = minGSSize,
-                  maxGSSize = maxGSSize,
-                  eps_dose = eps_dose,
-                  pvalueCutoff = pvalueCutoff,
-                  pAdjustMethod = pAdjustMethod,
-                  verbose = verbose,
-                  USER_DATA = USER_DATA,
-                  seed = seed,
-                  by = by)
+    
+    if(missing(nPerm)) {
+        GSEA_internal(geneList      = geneList,
+                      exponent      = exponent,
+                      minGSSize     = minGSSize,
+                      maxGSSize     = maxGSSize,
+                      eps           = eps,
+                      pvalueCutoff  = pvalueCutoff,
+                      pAdjustMethod = pAdjustMethod,
+                      verbose       = verbose,
+                      USER_DATA     = USER_DATA,
+                      seed          = seed,
+                      by            = by)
+    } else {
+        GSEA_internal(geneList      = geneList,
+                      exponent      = exponent,
+                      nPerm         = nPerm,
+                      minGSSize     = minGSSize,
+                      maxGSSize     = maxGSSize,
+                      pvalueCutoff  = pvalueCutoff,
+                      pAdjustMethod = pAdjustMethod,
+                      verbose       = verbose,
+                      USER_DATA     = USER_DATA,
+                      seed          = seed,
+                      by            = by)
+    }
+    
 }
 

--- a/R/gseAnalyzer.R
+++ b/R/gseAnalyzer.R
@@ -89,7 +89,6 @@ gseGO <- function(geneList,
 ##' @param organism supported organism listed in 'http://www.genome.jp/kegg/catalog/org_list.html'
 ##' @param keyType one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'
 ##' @param exponent weight of each step
-##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
 ##' @param eps This parameter sets the boundary for calculating the p value.
@@ -98,6 +97,7 @@ gseGO <- function(geneList,
 ##' @param verbose print message or not
 ##' @param seed logical
 ##' @param by one of 'fgsea' or 'DOSE'
+##' @param ... other parameter
 ##' @export
 ##' @return gseaResult object
 ##' @author Yu Guangchuang
@@ -105,7 +105,6 @@ gseMKEGG <- function(geneList,
                      organism          = 'hsa',
                      keyType           = 'kegg',
                      exponent          = 1,
-                     nPerm             = 1000,
                      minGSSize         = 10,
                      maxGSSize         = 500,
                      eps               = 1e-10,
@@ -113,36 +112,24 @@ gseMKEGG <- function(geneList,
                      pAdjustMethod     = "BH",
                      verbose           = TRUE,
                      seed              = FALSE,
-                     by                = 'fgsea') {
+                     by                = 'fgsea',
+                     ...) {
 
     species <- organismMapper(organism)
     KEGG_DATA <- prepare_KEGG(species, "MKEGG", keyType)
     
-    if(missing(nPerm)) {
-        res <-  GSEA_internal(geneList       = geneList,
-                              exponent       = exponent,
-                              minGSSize      = minGSSize,
-                              maxGSSize      = maxGSSize,
-                              eps            = eps,
-                              pvalueCutoff   = pvalueCutoff,
-                              pAdjustMethod  = pAdjustMethod,
-                              verbose        = verbose,
-                              USER_DATA      = KEGG_DATA,
-                              seed           = seed,
-                              by             = by)
-    } else {
-        res <-  GSEA_internal(geneList       = geneList,
-                              exponent       = exponent,
-                              nPerm          = nPerm,
-                              minGSSize      = minGSSize,
-                              maxGSSize      = maxGSSize,
-                              pvalueCutoff   = pvalueCutoff,
-                              pAdjustMethod  = pAdjustMethod,
-                              verbose        = verbose,
-                              USER_DATA      = KEGG_DATA,
-                              seed           = seed,
-                              by             = by)
-    }
+    res <-  GSEA_internal(geneList       = geneList,
+                          exponent       = exponent,
+                          minGSSize      = minGSSize,
+                          maxGSSize      = maxGSSize,
+                          eps            = eps,
+                          pvalueCutoff   = pvalueCutoff,
+                          pAdjustMethod  = pAdjustMethod,
+                          verbose        = verbose,
+                          USER_DATA      = KEGG_DATA,
+                          seed           = seed,
+                          by             = by,
+                          ...)
    
 
     if (is.null(res))
@@ -170,7 +157,6 @@ gseKEGG <- function(geneList,
                     organism          = 'hsa',
                     keyType           = 'kegg',
                     exponent          = 1,
-                    nPerm             = 1000,
                     minGSSize         = 10,
                     maxGSSize         = 500,
                     eps               = 1e-10,
@@ -179,7 +165,8 @@ gseKEGG <- function(geneList,
                     verbose           = TRUE,
                     use_internal_data = FALSE,
                     seed              = FALSE,
-                    by                = 'fgsea') {
+                    by                = 'fgsea',
+                    ...) {
 
     species <- organismMapper(organism)
     if (use_internal_data) {
@@ -188,31 +175,18 @@ gseKEGG <- function(geneList,
         KEGG_DATA <- prepare_KEGG(species, "KEGG", keyType)
     }
 
-    if(missing(nPerm)) {
-        res <-  GSEA_internal(geneList         = geneList,
-                              exponent         = exponent,
-                              minGSSize        = minGSSize,
-                              maxGSSize        = maxGSSize,
-                              eps              = eps,
-                              pvalueCutoff     = pvalueCutoff,
-                              pAdjustMethod    = pAdjustMethod,
-                              verbose          = verbose,
-                              USER_DATA        = KEGG_DATA,
-                              seed             = seed,
-                              by               = by)
-    } else {
-        res <-  GSEA_internal(geneList         = geneList,
-                              exponent         = exponent,
-                              nPerm            = nPerm,
-                              minGSSize        = minGSSize,
-                              maxGSSize        = maxGSSize,
-                              pvalueCutoff     = pvalueCutoff,
-                              pAdjustMethod    = pAdjustMethod,
-                              verbose          = verbose,
-                              USER_DATA        = KEGG_DATA,
-                              seed             = seed,
-                              by               = by)
-    }
+    res <-  GSEA_internal(geneList         = geneList,
+                          exponent         = exponent,
+                          minGSSize        = minGSSize,
+                          maxGSSize        = maxGSSize,
+                          eps              = eps,
+                          pvalueCutoff     = pvalueCutoff,
+                          pAdjustMethod    = pAdjustMethod,
+                          verbose          = verbose,
+                          USER_DATA        = KEGG_DATA,
+                          seed             = seed,
+                          by               = by,
+                          ...)
     
 
     if (is.null(res))

--- a/R/gseAnalyzer.R
+++ b/R/gseAnalyzer.R
@@ -7,9 +7,10 @@
 ##' @param OrgDb OrgDb
 ##' @param keyType keytype of gene
 ##' @param exponent weight of each step
+##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
-##' @param eps_dose This parameter sets the boundary for calculating the p value.
+##' @param eps This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue Cutoff
 ##' @param pAdjustMethod pvalue adjustment method
 ##' @param verbose print message or not
@@ -24,33 +25,46 @@ gseGO <- function(geneList,
                   OrgDb,
                   keyType       = "ENTREZID",
                   exponent      = 1,
-                  #nPerm         = 1000,
+                  nPerm         = 1000,
                   minGSSize     = 10,
                   maxGSSize     = 500,
-                  eps_dose = 1e-10,
+                  eps           = 1e-10,
                   pvalueCutoff  = 0.05,
                   pAdjustMethod = "BH",
                   verbose       = TRUE,
                   seed          = FALSE,
-                  by = 'fgsea') {
+                  by            = 'fgsea') {
 
     ont %<>% toupper
     ont <- match.arg(ont, c("BP", "MF", "CC", "ALL"))
 
     GO_DATA <- get_GO_data(OrgDb, ont, keyType)
-
-    res <-  GSEA_internal(geneList = geneList,
-                          exponent = exponent,
-                          #nPerm = nPerm,
-                          minGSSize = minGSSize,
-                          maxGSSize = maxGSSize,
-                          eps_dose = eps_dose,
-                          pvalueCutoff = pvalueCutoff,
-                          pAdjustMethod = pAdjustMethod,
-                          verbose = verbose,
-                          USER_DATA = GO_DATA,
-                          seed = seed,
-                          by = by)
+    if(missing(nPerm)) {
+        res <-  GSEA_internal(geneList      = geneList,
+                              exponent      = exponent,
+                              minGSSize     = minGSSize,
+                              maxGSSize     = maxGSSize,
+                              eps           = eps,
+                              pvalueCutoff  = pvalueCutoff,
+                              pAdjustMethod = pAdjustMethod,
+                              verbose       = verbose,
+                              USER_DATA     = GO_DATA,
+                              seed          = seed,
+                              by            = by)
+    } else {
+        res <-  GSEA_internal(geneList      = geneList,
+                              exponent      = exponent,
+                              nPerm         = nPerm,
+                              minGSSize     = minGSSize,
+                              maxGSSize     = maxGSSize,
+                              pvalueCutoff  = pvalueCutoff,
+                              pAdjustMethod = pAdjustMethod,
+                              verbose       = verbose,
+                              USER_DATA     = GO_DATA,
+                              seed          = seed,
+                              by            = by)
+    }
+    
 
     if (is.null(res))
         return(res)
@@ -75,9 +89,10 @@ gseGO <- function(geneList,
 ##' @param organism supported organism listed in 'http://www.genome.jp/kegg/catalog/org_list.html'
 ##' @param keyType one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'
 ##' @param exponent weight of each step
+##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
-##' @param eps_dose This parameter sets the boundary for calculating the p value.
+##' @param eps This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue Cutoff
 ##' @param pAdjustMethod pvalue adjustment method
 ##' @param verbose print message or not
@@ -90,31 +105,45 @@ gseMKEGG <- function(geneList,
                      organism          = 'hsa',
                      keyType           = 'kegg',
                      exponent          = 1,
-                     #nPerm             = 1000,
+                     nPerm             = 1000,
                      minGSSize         = 10,
                      maxGSSize         = 500,
-                     eps_dose = 1e-10,
+                     eps               = 1e-10,
                      pvalueCutoff      = 0.05,
                      pAdjustMethod     = "BH",
                      verbose           = TRUE,
-                     seed = FALSE,
-                     by = 'fgsea') {
+                     seed              = FALSE,
+                     by                = 'fgsea') {
 
     species <- organismMapper(organism)
     KEGG_DATA <- prepare_KEGG(species, "MKEGG", keyType)
-
-    res <-  GSEA_internal(geneList = geneList,
-                          exponent = exponent,
-                          #nPerm = nPerm,
-                          minGSSize = minGSSize,
-                          maxGSSize = maxGSSize,
-                          eps_dose = eps_dose,
-                          pvalueCutoff = pvalueCutoff,
-                          pAdjustMethod = pAdjustMethod,
-                          verbose = verbose,
-                          USER_DATA = KEGG_DATA,
-                          seed = seed,
-                          by = by)
+    
+    if(missing(nPerm)) {
+        res <-  GSEA_internal(geneList       = geneList,
+                              exponent       = exponent,
+                              minGSSize      = minGSSize,
+                              maxGSSize      = maxGSSize,
+                              eps            = eps,
+                              pvalueCutoff   = pvalueCutoff,
+                              pAdjustMethod  = pAdjustMethod,
+                              verbose        = verbose,
+                              USER_DATA      = KEGG_DATA,
+                              seed           = seed,
+                              by             = by)
+    } else {
+        res <-  GSEA_internal(geneList       = geneList,
+                              exponent       = exponent,
+                              nPerm          = nPerm,
+                              minGSSize      = minGSSize,
+                              maxGSSize      = maxGSSize,
+                              pvalueCutoff   = pvalueCutoff,
+                              pAdjustMethod  = pAdjustMethod,
+                              verbose        = verbose,
+                              USER_DATA      = KEGG_DATA,
+                              seed           = seed,
+                              by             = by)
+    }
+   
 
     if (is.null(res))
         return(res)
@@ -141,16 +170,16 @@ gseKEGG <- function(geneList,
                     organism          = 'hsa',
                     keyType           = 'kegg',
                     exponent          = 1,
-                    #nPerm             = 1000,
+                    nPerm             = 1000,
                     minGSSize         = 10,
                     maxGSSize         = 500,
-                    eps_dose          = 1e-10,
+                    eps               = 1e-10,
                     pvalueCutoff      = 0.05,
                     pAdjustMethod     = "BH",
                     verbose           = TRUE,
                     use_internal_data = FALSE,
                     seed              = FALSE,
-                    by = 'fgsea') {
+                    by                = 'fgsea') {
 
     species <- organismMapper(organism)
     if (use_internal_data) {
@@ -159,18 +188,32 @@ gseKEGG <- function(geneList,
         KEGG_DATA <- prepare_KEGG(species, "KEGG", keyType)
     }
 
-    res <-  GSEA_internal(geneList = geneList,
-                          exponent = exponent,
-                          #nPerm = nPerm,
-                          minGSSize = minGSSize,
-                          maxGSSize = maxGSSize,
-                          eps_dose = eps_dose,
-                          pvalueCutoff = pvalueCutoff,
-                          pAdjustMethod = pAdjustMethod,
-                          verbose = verbose,
-                          USER_DATA = KEGG_DATA,
-                          seed = seed,
-                          by = by)
+    if(missing(nPerm)) {
+        res <-  GSEA_internal(geneList         = geneList,
+                              exponent         = exponent,
+                              minGSSize        = minGSSize,
+                              maxGSSize        = maxGSSize,
+                              eps              = eps,
+                              pvalueCutoff     = pvalueCutoff,
+                              pAdjustMethod    = pAdjustMethod,
+                              verbose          = verbose,
+                              USER_DATA        = KEGG_DATA,
+                              seed             = seed,
+                              by               = by)
+    } else {
+        res <-  GSEA_internal(geneList         = geneList,
+                              exponent         = exponent,
+                              nPerm            = nPerm,
+                              minGSSize        = minGSSize,
+                              maxGSSize        = maxGSSize,
+                              pvalueCutoff     = pvalueCutoff,
+                              pAdjustMethod    = pAdjustMethod,
+                              verbose          = verbose,
+                              USER_DATA        = KEGG_DATA,
+                              seed             = seed,
+                              by               = by)
+    }
+    
 
     if (is.null(res))
         return(res)

--- a/R/gseAnalyzer.R
+++ b/R/gseAnalyzer.R
@@ -7,7 +7,6 @@
 ##' @param OrgDb OrgDb
 ##' @param keyType keytype of gene
 ##' @param exponent weight of each step
-##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
 ##' @param eps This parameter sets the boundary for calculating the p value.
@@ -16,6 +15,7 @@
 ##' @param verbose print message or not
 ##' @param seed logical
 ##' @param by one of 'fgsea' or 'DOSE'
+##' @param ... other parameter
 ##' @importClassesFrom DOSE gseaResult
 ##' @export
 ##' @return gseaResult object
@@ -25,7 +25,6 @@ gseGO <- function(geneList,
                   OrgDb,
                   keyType       = "ENTREZID",
                   exponent      = 1,
-                  nPerm         = 1000,
                   minGSSize     = 10,
                   maxGSSize     = 500,
                   eps           = 1e-10,
@@ -33,37 +32,27 @@ gseGO <- function(geneList,
                   pAdjustMethod = "BH",
                   verbose       = TRUE,
                   seed          = FALSE,
-                  by            = 'fgsea') {
+                  by            = 'fgsea',
+                  ...) {
 
     ont %<>% toupper
     ont <- match.arg(ont, c("BP", "MF", "CC", "ALL"))
 
     GO_DATA <- get_GO_data(OrgDb, ont, keyType)
-    if(missing(nPerm)) {
-        res <-  GSEA_internal(geneList      = geneList,
-                              exponent      = exponent,
-                              minGSSize     = minGSSize,
-                              maxGSSize     = maxGSSize,
-                              eps           = eps,
-                              pvalueCutoff  = pvalueCutoff,
-                              pAdjustMethod = pAdjustMethod,
-                              verbose       = verbose,
-                              USER_DATA     = GO_DATA,
-                              seed          = seed,
-                              by            = by)
-    } else {
-        res <-  GSEA_internal(geneList      = geneList,
-                              exponent      = exponent,
-                              nPerm         = nPerm,
-                              minGSSize     = minGSSize,
-                              maxGSSize     = maxGSSize,
-                              pvalueCutoff  = pvalueCutoff,
-                              pAdjustMethod = pAdjustMethod,
-                              verbose       = verbose,
-                              USER_DATA     = GO_DATA,
-                              seed          = seed,
-                              by            = by)
-    }
+
+    res <-  GSEA_internal(geneList      = geneList,
+                          exponent      = exponent,
+                          minGSSize     = minGSSize,
+                          maxGSSize     = maxGSSize,
+                          eps           = eps,
+                          pvalueCutoff  = pvalueCutoff,
+                          pAdjustMethod = pAdjustMethod,
+                          verbose       = verbose,
+                          USER_DATA     = GO_DATA,
+                          seed          = seed,
+                          by            = by,
+                          ...)
+  
     
 
     if (is.null(res))

--- a/R/gseAnalyzer.R
+++ b/R/gseAnalyzer.R
@@ -7,9 +7,9 @@
 ##' @param OrgDb OrgDb
 ##' @param keyType keytype of gene
 ##' @param exponent weight of each step
-##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
+##' @param eps_dose This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue Cutoff
 ##' @param pAdjustMethod pvalue adjustment method
 ##' @param verbose print message or not
@@ -24,9 +24,10 @@ gseGO <- function(geneList,
                   OrgDb,
                   keyType       = "ENTREZID",
                   exponent      = 1,
-                  nPerm         = 1000,
+                  #nPerm         = 1000,
                   minGSSize     = 10,
                   maxGSSize     = 500,
+                  eps_dose = 1e-10,
                   pvalueCutoff  = 0.05,
                   pAdjustMethod = "BH",
                   verbose       = TRUE,
@@ -40,9 +41,10 @@ gseGO <- function(geneList,
 
     res <-  GSEA_internal(geneList = geneList,
                           exponent = exponent,
-                          nPerm = nPerm,
+                          #nPerm = nPerm,
                           minGSSize = minGSSize,
                           maxGSSize = maxGSSize,
+                          eps_dose = eps_dose,
                           pvalueCutoff = pvalueCutoff,
                           pAdjustMethod = pAdjustMethod,
                           verbose = verbose,
@@ -73,9 +75,9 @@ gseGO <- function(geneList,
 ##' @param organism supported organism listed in 'http://www.genome.jp/kegg/catalog/org_list.html'
 ##' @param keyType one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'
 ##' @param exponent weight of each step
-##' @param nPerm permutation numbers
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
+##' @param eps_dose This parameter sets the boundary for calculating the p value.
 ##' @param pvalueCutoff pvalue Cutoff
 ##' @param pAdjustMethod pvalue adjustment method
 ##' @param verbose print message or not
@@ -88,9 +90,10 @@ gseMKEGG <- function(geneList,
                      organism          = 'hsa',
                      keyType           = 'kegg',
                      exponent          = 1,
-                     nPerm             = 1000,
+                     #nPerm             = 1000,
                      minGSSize         = 10,
                      maxGSSize         = 500,
+                     eps_dose = 1e-10,
                      pvalueCutoff      = 0.05,
                      pAdjustMethod     = "BH",
                      verbose           = TRUE,
@@ -102,9 +105,10 @@ gseMKEGG <- function(geneList,
 
     res <-  GSEA_internal(geneList = geneList,
                           exponent = exponent,
-                          nPerm = nPerm,
+                          #nPerm = nPerm,
                           minGSSize = minGSSize,
                           maxGSSize = maxGSSize,
+                          eps_dose = eps_dose,
                           pvalueCutoff = pvalueCutoff,
                           pAdjustMethod = pAdjustMethod,
                           verbose = verbose,
@@ -137,9 +141,10 @@ gseKEGG <- function(geneList,
                     organism          = 'hsa',
                     keyType           = 'kegg',
                     exponent          = 1,
-                    nPerm             = 1000,
+                    #nPerm             = 1000,
                     minGSSize         = 10,
                     maxGSSize         = 500,
+                    eps_dose          = 1e-10,
                     pvalueCutoff      = 0.05,
                     pAdjustMethod     = "BH",
                     verbose           = TRUE,
@@ -156,9 +161,10 @@ gseKEGG <- function(geneList,
 
     res <-  GSEA_internal(geneList = geneList,
                           exponent = exponent,
-                          nPerm = nPerm,
+                          #nPerm = nPerm,
                           minGSSize = minGSSize,
                           maxGSSize = maxGSSize,
+                          eps_dose = eps_dose,
                           pvalueCutoff = pvalueCutoff,
                           pAdjustMethod = pAdjustMethod,
                           verbose = verbose,

--- a/man/GSEA.Rd
+++ b/man/GSEA.Rd
@@ -7,9 +7,10 @@
 GSEA(
   geneList,
   exponent = 1,
+  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
-  eps_dose = 1e-10,
+  eps = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   TERM2GENE,
@@ -24,11 +25,13 @@ GSEA(
 
 \item{exponent}{weight of each step}
 
+\item{nPerm}{permutation numbers}
+
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
 
-\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
+\item{eps}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue cutoff}
 

--- a/man/GSEA.Rd
+++ b/man/GSEA.Rd
@@ -7,9 +7,9 @@
 GSEA(
   geneList,
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
+  eps_dose = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   TERM2GENE,
@@ -24,11 +24,11 @@ GSEA(
 
 \item{exponent}{weight of each step}
 
-\item{nPerm}{number of permutations}
-
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
+
+\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue cutoff}
 

--- a/man/GSEA.Rd
+++ b/man/GSEA.Rd
@@ -7,7 +7,6 @@
 GSEA(
   geneList,
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
   eps = 1e-10,
@@ -17,15 +16,14 @@ GSEA(
   TERM2NAME = NA,
   verbose = TRUE,
   seed = FALSE,
-  by = "fgsea"
+  by = "fgsea",
+  ...
 )
 }
 \arguments{
 \item{geneList}{order ranked geneList}
 
 \item{exponent}{weight of each step}
-
-\item{nPerm}{permutation numbers}
 
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
@@ -46,6 +44,8 @@ GSEA(
 \item{seed}{logical}
 
 \item{by}{one of 'fgsea' or 'DOSE'}
+
+\item{...}{other parameter}
 }
 \value{
 gseaResult object

--- a/man/gseGO.Rd
+++ b/man/gseGO.Rd
@@ -10,9 +10,9 @@ gseGO(
   OrgDb,
   keyType = "ENTREZID",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
+  eps_dose = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -31,11 +31,11 @@ gseGO(
 
 \item{exponent}{weight of each step}
 
-\item{nPerm}{permutation numbers}
-
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
+
+\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 

--- a/man/gseGO.Rd
+++ b/man/gseGO.Rd
@@ -10,7 +10,6 @@ gseGO(
   OrgDb,
   keyType = "ENTREZID",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
   eps = 1e-10,
@@ -18,7 +17,8 @@ gseGO(
   pAdjustMethod = "BH",
   verbose = TRUE,
   seed = FALSE,
-  by = "fgsea"
+  by = "fgsea",
+  ...
 )
 }
 \arguments{
@@ -31,8 +31,6 @@ gseGO(
 \item{keyType}{keytype of gene}
 
 \item{exponent}{weight of each step}
-
-\item{nPerm}{permutation numbers}
 
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
@@ -49,6 +47,8 @@ gseGO(
 \item{seed}{logical}
 
 \item{by}{one of 'fgsea' or 'DOSE'}
+
+\item{...}{other parameter}
 }
 \value{
 gseaResult object

--- a/man/gseGO.Rd
+++ b/man/gseGO.Rd
@@ -10,9 +10,10 @@ gseGO(
   OrgDb,
   keyType = "ENTREZID",
   exponent = 1,
+  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
-  eps_dose = 1e-10,
+  eps = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -31,11 +32,13 @@ gseGO(
 
 \item{exponent}{weight of each step}
 
+\item{nPerm}{permutation numbers}
+
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
 
-\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
+\item{eps}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 

--- a/man/gseKEGG.Rd
+++ b/man/gseKEGG.Rd
@@ -9,7 +9,6 @@ gseKEGG(
   organism = "hsa",
   keyType = "kegg",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
   eps = 1e-10,
@@ -18,7 +17,8 @@ gseKEGG(
   verbose = TRUE,
   use_internal_data = FALSE,
   seed = FALSE,
-  by = "fgsea"
+  by = "fgsea",
+  ...
 )
 }
 \arguments{
@@ -29,8 +29,6 @@ gseKEGG(
 \item{keyType}{one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'}
 
 \item{exponent}{weight of each step}
-
-\item{nPerm}{permutation numbers}
 
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
@@ -49,6 +47,8 @@ gseKEGG(
 \item{seed}{logical}
 
 \item{by}{one of 'fgsea' or 'DOSE'}
+
+\item{...}{other parameter}
 }
 \value{
 gseaResult object

--- a/man/gseKEGG.Rd
+++ b/man/gseKEGG.Rd
@@ -9,9 +9,10 @@ gseKEGG(
   organism = "hsa",
   keyType = "kegg",
   exponent = 1,
+  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
-  eps_dose = 1e-10,
+  eps = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -29,11 +30,13 @@ gseKEGG(
 
 \item{exponent}{weight of each step}
 
+\item{nPerm}{permutation numbers}
+
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
 
-\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
+\item{eps}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 

--- a/man/gseKEGG.Rd
+++ b/man/gseKEGG.Rd
@@ -9,9 +9,9 @@ gseKEGG(
   organism = "hsa",
   keyType = "kegg",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
+  eps_dose = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -29,11 +29,11 @@ gseKEGG(
 
 \item{exponent}{weight of each step}
 
-\item{nPerm}{permutation numbers}
-
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
+
+\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 

--- a/man/gseMKEGG.Rd
+++ b/man/gseMKEGG.Rd
@@ -9,9 +9,10 @@ gseMKEGG(
   organism = "hsa",
   keyType = "kegg",
   exponent = 1,
+  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
-  eps_dose = 1e-10,
+  eps = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -28,11 +29,13 @@ gseMKEGG(
 
 \item{exponent}{weight of each step}
 
+\item{nPerm}{permutation numbers}
+
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
 
-\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
+\item{eps}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 

--- a/man/gseMKEGG.Rd
+++ b/man/gseMKEGG.Rd
@@ -9,9 +9,9 @@ gseMKEGG(
   organism = "hsa",
   keyType = "kegg",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
+  eps_dose = 1e-10,
   pvalueCutoff = 0.05,
   pAdjustMethod = "BH",
   verbose = TRUE,
@@ -28,11 +28,11 @@ gseMKEGG(
 
 \item{exponent}{weight of each step}
 
-\item{nPerm}{permutation numbers}
-
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
 \item{maxGSSize}{maximal size of genes annotated for testing}
+
+\item{eps_dose}{This parameter sets the boundary for calculating the p value.}
 
 \item{pvalueCutoff}{pvalue Cutoff}
 

--- a/man/gseMKEGG.Rd
+++ b/man/gseMKEGG.Rd
@@ -9,7 +9,6 @@ gseMKEGG(
   organism = "hsa",
   keyType = "kegg",
   exponent = 1,
-  nPerm = 1000,
   minGSSize = 10,
   maxGSSize = 500,
   eps = 1e-10,
@@ -17,7 +16,8 @@ gseMKEGG(
   pAdjustMethod = "BH",
   verbose = TRUE,
   seed = FALSE,
-  by = "fgsea"
+  by = "fgsea",
+  ...
 )
 }
 \arguments{
@@ -28,8 +28,6 @@ gseMKEGG(
 \item{keyType}{one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'}
 
 \item{exponent}{weight of each step}
-
-\item{nPerm}{permutation numbers}
 
 \item{minGSSize}{minimal size of each geneSet for analyzing}
 
@@ -46,6 +44,8 @@ gseMKEGG(
 \item{seed}{logical}
 
 \item{by}{one of 'fgsea' or 'DOSE'}
+
+\item{...}{other parameter}
 }
 \value{
 gseaResult object


### PR DESCRIPTION
对调用了fgsea的几个函数进行了升级，去掉了 `nPerm` 参数，增加了 `eps_dose` 参数。
调用关系为：
GSEA_internal被gseMKEGG，GSEA，gseKEGG和gseGO调用