### PR TITLE
Change the download method for KEGG data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: clusterProfiler
 Type: Package
 Title: statistical analysis and visualization of functional profiles for
     genes and gene clusters
-Version: 3.17.1
+Version: 3.17.2
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),

--- a/R/enricher.R
+++ b/R/enricher.R
@@ -3,7 +3,7 @@
 ##'
 ##' @title enricher
 ##' @param gene a vector of gene id
-##' @param pvalueCutoff pvalue cutoff on enrichment tests to report
+##' @param pvalueCutoff adjusted pvalue cutoff on enrichment tests to report
 ##' @param pAdjustMethod  one of "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none"
 ##' @param universe background genes. If missing, the all genes listed in the database (eg TERM2GENE table) will be used as background.
 ##' @param minGSSize minimal size of genes annotated for testing
@@ -44,7 +44,7 @@ enricher <- function(gene,
 ##' @param minGSSize minimal size of each geneSet for analyzing
 ##' @param maxGSSize maximal size of genes annotated for testing
 ##' @param eps This parameter sets the boundary for calculating the p value.
-##' @param pvalueCutoff pvalue cutoff
+##' @param pvalueCutoff adjusted pvalue cutoff
 ##' @param pAdjustMethod p value adjustment method
 ##' @param TERM2GENE user input annotation of TERM TO GENE mapping, a data.frame of 2 column with term and gene
 ##' @param TERM2NAME user input of TERM TO NAME mapping, a data.frame of 2 column with term and name

--- a/R/kegg-utilities.R
+++ b/R/kegg-utilities.R
@@ -92,8 +92,15 @@ kegg_rest <- function(rest_url) {
 
     message("Reading KEGG annotation online:\n" )
     f <- tempfile()
-    dl <- tryCatch(downloader::download(rest_url, destfile = f, quiet = TRUE),
+    ## dl <- tryCatch(downloader::download(rest_url, destfile = f, quiet = TRUE),
+    if (capabilities("libcurl")) {
+        dl <- tryCatch(utils::download.file(rest_url, destfile = f, quiet = TRUE, method = "libcurl"),
                    error = function(e) NULL)
+    } else {
+        dl <- tryCatch(downloader::download(rest_url, destfile = f, quiet = TRUE),
+                   error = function(e) NULL)
+    }
+    
     if (is.null(dl)) {
         message("fail to download KEGG data...")
         return(NULL)

--- a/man/GSEA.Rd
+++ b/man/GSEA.Rd
@@ -31,7 +31,7 @@ GSEA(
 
 \item{eps}{This parameter sets the boundary for calculating the p value.}
 
-\item{pvalueCutoff}{pvalue cutoff}
+\item{pvalueCutoff}{adjusted pvalue cutoff}
 
 \item{pAdjustMethod}{p value adjustment method}
 

--- a/man/enrichDAVID.Rd
+++ b/man/enrichDAVID.Rd
@@ -31,7 +31,7 @@ enrichDAVID(
 
 \item{annotation}{david annotation}
 
-\item{pvalueCutoff}{pvalue cutoff on enrichment tests to report}
+\item{pvalueCutoff}{adjusted pvalue cutoff on enrichment tests to report}
 
 \item{pAdjustMethod}{one of "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none"}
 

--- a/man/enrichGO.Rd
+++ b/man/enrichGO.Rd
@@ -30,7 +30,7 @@ enrichGO(
 
 \item{ont}{One of "BP", "MF", and "CC" subontologies, or "ALL" for all three.}
 
-\item{pvalueCutoff}{pvalue cutoff on enrichment tests to report}
+\item{pvalueCutoff}{adjusted pvalue cutoff on enrichment tests to report}
 
 \item{pAdjustMethod}{one of "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none"}
 

--- a/man/enrichKEGG.Rd
+++ b/man/enrichKEGG.Rd
@@ -26,7 +26,7 @@ enrichKEGG(
 
 \item{keyType}{one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'}
 
-\item{pvalueCutoff}{pvalue cutoff on enrichment tests to report}
+\item{pvalueCutoff}{adjusted pvalue cutoff on enrichment tests to report}
 
 \item{pAdjustMethod}{one of "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none"}
 

--- a/man/enrichMKEGG.Rd
+++ b/man/enrichMKEGG.Rd
@@ -25,7 +25,7 @@ enrichMKEGG(
 
 \item{keyType}{one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'}
 
-\item{pvalueCutoff}{pvalue cutoff on enrichment tests to report}
+\item{pvalueCutoff}{adjusted pvalue cutoff on enrichment tests to report}
 
 \item{pAdjustMethod}{one of "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none"}
 

--- a/man/enricher.Rd
+++ b/man/enricher.Rd
@@ -19,7 +19,7 @@ enricher(
 \arguments{
 \item{gene}{a vector of gene id}
 
-\item{pvalueCutoff}{pvalue cutoff on enrichment tests to report}
+\item{pvalueCutoff}{adjusted pvalue cutoff on enrichment tests to report}
 
 \item{pAdjustMethod}{one of "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none"}
 


### PR DESCRIPTION
由于`downloader::download`在下载KEGG信息时常常下载不完全，而又不会给出下载的文件是否完整的提示信息，这导致了用户使用`enrichKEGG`等与KEGG相关的富集分析函数时出现运行多次但每次结果不一致的情况。我改用`download.file(url, destfile = f, quiet = FALSE, method="libcurl")`来下载，经过测试，可以下载到完整数据。
另外，`enrichGO`等函数的参数`pvalueCutoff`实际上控制的是矫正后的P值，因此我在函数的文档中加了个“adjusted”。