### PR TITLE
Move as.data.frame.compareCluster to enrichplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: clusterProfiler
 Type: Package
 Title: statistical analysis and visualization of functional profiles for
     genes and gene clusters
-Version: 3.17.3
+Version: 3.17.4
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),
@@ -18,7 +18,7 @@ Imports:
     downloader,
     DOSE (>= 3.13.1),
     dplyr,
-    enrichplot (>= 1.7.1),
+    enrichplot (>= 1.9.3),
     GO.db,
     GOSemSim,
     magrittr,

--- a/R/accessor.R
+++ b/R/accessor.R
@@ -1,8 +1,6 @@
 ##' @method as.data.frame compareClusterResult
 ##' @export
-as.data.frame.compareClusterResult <- function(x, ...) {
-    as.data.frame(x@compareClusterResult, ...)
-}
+as.data.frame.compareClusterResult <- getFromNamespace("as.data.frame.compareClusterResult", "enrichplot")
 
 ##' @method as.data.frame groupGOResult
 ##' @export


### PR DESCRIPTION
将`as.data.frame.compareClusterResult`从`clusterProfiler`移到了`enrichplot`。因为S3 method无法在NAMESPACE中export，因此使用了`getFromNamespace("as.data.frame.compareClusterResult", "enrichplot")`