### PR TITLE
remove argument, calculate adjusted p-value

### DIFF
--- a/R/enrichDAVID.R
+++ b/R/enrichDAVID.R
@@ -100,7 +100,7 @@ enrichDAVID <- function(gene,
     }
     
     if (nrow(x) == 0) {
-        warning("No enriched GO term found...")
+        warning("No enriched term found...")
         return(NULL)
     }
     

--- a/R/enrichDAVID.R
+++ b/R/enrichDAVID.R
@@ -96,7 +96,7 @@ enrichDAVID <- function(gene,
     x <- getFunctionalAnnotationChart(david, threshold=1, count=minGSSize)
     
     if (!is.na(maxGSSize) && !is.null(maxGSSize)) {
-        x <- x[x$Count <= maxGSSize, ]
+        x <- x[x$Pop.Hits <= maxGSSize, ]
     }
     
     if (nrow(x) == 0) {

--- a/R/enrichDAVID.R
+++ b/R/enrichDAVID.R
@@ -8,7 +8,6 @@
 ##' @param maxGSSize maximal size of genes annotated for testing
 ##' @param annotation david annotation
 ##' @inheritParams enricher
-##' @param species species
 ##' @param david.user david user
 ##' @return A \code{enrichResult} instance
 ## @importFrom RDAVIDWebService DAVIDWebService
@@ -29,19 +28,18 @@ enrichDAVID <- function(gene,
                         pvalueCutoff  = 0.05,
                         pAdjustMethod = "BH",
                         qvalueCutoff  = 0.2,
-                        species       = NA,
                         david.user){
-
+    
     Count <- List.Total <- Pop.Hits <- Pop.Total <- NULL
-
+    
     pAdjustMethod <- match.arg(pAdjustMethod, c("bonferroni", "BH"))
-
+    
     david.pkg <- "RDAVIDWebService"
     pkgs <- installed.packages()[,1]
     if (! david.pkg %in% pkgs) {
         stop("You should have RDAVIDWebService package installed before using enrichDAVID...")
     }
-
+    
     require(david.pkg, character.only=TRUE)
     DAVIDWebService <- eval(parse(text="DAVIDWebService"))
     addList <- eval(parse(text="addList"))
@@ -49,10 +47,10 @@ enrichDAVID <- function(gene,
     getFunctionalAnnotationChart <- eval(parse(text="getFunctionalAnnotationChart"))
     getSpecieNames <- eval(parse(text="getSpecieNames"))
     getIdTypes <- eval(parse(text="getIdTypes"))
-
+    
     david <- DAVIDWebService$new(email=david.user,
                                  url="https://david.ncifcrf.gov/webservice/services/DAVIDWebService.DAVIDWebServiceHttpSoap12Endpoint/")
-
+    
     ## addList will throw error if idType is not match.
     ## use match.arg to check before addList make it more readable
     
@@ -82,86 +80,68 @@ enrichDAVID <- function(gene,
     david.res <- addList(david, gene, idType=idType,
                          listName="clusterProfiler",
                          listType="Gene")
-
-
+    
+    
     if (david.res$inDavid == 0) {
         stop("All id can not be mapped. Please check 'idType' parameter...")
     }
-
+    
     if (!missing(universe)) {
         david.res <- addList(david, universe, idType=idType,
                              listName="universe",
                              listType="Background")
     }
-
+    
     setAnnotationCategories(david, annotation)
     x <- getFunctionalAnnotationChart(david, threshold=1, count=minGSSize)
-
-    if (length(x@.Data) == 0) {
-        warning("No significant enrichment found...")
+    
+    if (!is.na(maxGSSize) && !is.null(maxGSSize)) {
+        x <- x[x$Count <= maxGSSize, ]
+    }
+    
+    if (nrow(x) == 0) {
+        warning("No enriched GO term found...")
         return(NULL)
     }
-
-    term <- x$Term
-    if (length(grep("~", term[1])) == 0) {
-        sep <- ":"
-    } else {
-        sep <- "~"
-    }
-    term.list <- sapply(term, function(y) strsplit(y, split=sep))
-    term.df <- do.call("rbind", term.list)
-    ID <- term.df[,1]
-    Description <- term.df[,2]
-    GeneRatio <- with(x, paste(Count, List.Total, sep="/"))
-    BgRatio <- with(x, paste(Pop.Hits, Pop.Total, sep="/"))
-    Over <- data.frame(ID          = ID,
-                       Description = Description,
-                       GeneRatio   = GeneRatio,
-                       BgRatio     = BgRatio,
+    
+    sep <- ifelse(grepl("~", x$Term[1]), "~", ":")
+    term.df <- do.call("rbind", sapply(x$Term, function(y) strsplit(y, split=sep)))
+    
+    Over <- data.frame(ID          = term.df[,1],
+                       Description = term.df[,2],
+                       GeneRatio   = with(x, paste(Count, List.Total, sep="/")),
+                       BgRatio     = with(x, paste(Pop.Hits, Pop.Total, sep="/")),
                        pvalue      = x$PValue,
+                       p.adjust    = p.adjust(x$PValue, method = pAdjustMethod),
                        stringsAsFactors = FALSE)
-    row.names(Over) <- ID
-
-    if (pAdjustMethod == "bonferroni") {
-        Over$p.adjust <- x$Bonferroni
-    } else {
-        Over$p.adjust <- x$Benjamini
-    }
-
+    row.names(Over) <- Over$ID
+    
     qobj <- tryCatch(qvalue(p=Over$pvalue, lambda=0.05, pi0.method="bootstrap"),
                      error=function(e) NULL)
     if (class(qobj) == "qvalue") {
-        qvalues <- qobj$qvalues
+        Over$qvalue <- qobj$qvalues
     } else {
-        qvalues <- NA
+        Over$qvalue <- NA
     }
-    Over$qvalue <- qvalues
+    
     Over$geneID <- gsub(",\\s*", "/", x$Genes)
     Over$Count <- x$Count
-
-    Over <- Over[ Over$pvalue <= pvalueCutoff, ]
-    Over <- Over[ Over$p.adjust <= pvalueCutoff, ]
+    
+    Over <- Over[Over$p.adjust <= pvalueCutoff, ]
+    
     if (! any(is.na(Over$qvalue))) {
-        Over <- Over[ Over$qvalue <= qvalueCutoff, ]
+        Over <- Over[Over$qvalue <= qvalueCutoff, ]
     }
-
-    org <- getSpecieNames(david)
-    org <- gsub("\\(.*\\)", "", org)
-
-    ## gc <- strsplit(Over$geneID, "/")
-    ## names(gc) <- Over$ID
-
-    if (!is.na(maxGSSize) && !is.null(maxGSSize)) {
-        idx <- as.numeric(sub("/\\d+", "", Over$BgRatio)) <= maxGSSize
-        Over <- Over[idx,]
-    }
-
+    
+    species <- getSpecieNames(david)
+    species <- gsub("\\(.*\\)", "", species)
+    
     new("enrichResult",
         result         = Over,
         pvalueCutoff   = pvalueCutoff,
         pAdjustMethod  = pAdjustMethod,
         organism       = org,
-        ontology       = annotation, ## as.character(x$Category[1]),
+        ontology       = annotation,
         gene           = as.character(gene),
         keytype        = idType)
 }


### PR DESCRIPTION
* Remove argument "species" which was not used in function (by default, DAVID uses all species found in the user's gene list)
* Filter maximal background genes set size before p-value adjustment
* Small improvement in code