### PR TITLE
update `[`  and `[[` for compareClusterResult

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: clusterProfiler
 Type: Package
 Title: statistical analysis and visualization of functional profiles for
     genes and gene clusters
-Version: 3.17.4
+Version: 3.17.4.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# clusterProfiler 3.17.3.991
+
++ update `[` and `[[` of compareClusterResult
+
 # clusterProfiler 3.17.3
 
 + internal suports of enrichment analyses using WikiPathways (2020-09-09, Wed)

--- a/R/accessor.R
+++ b/R/accessor.R
@@ -22,7 +22,7 @@ as.data.frame.groupGOResult <- function(x, ...) {
 ##' @method [[ compareClusterResult
 ##' @export
 `[[.compareClusterResult` <- function(x, i) {
-    gc <- geneInCategory(x)
+    gc <- DOSE::geneInCategory2(x)
     ids <- grep(i, names(gc))
     # if (!i %in% names(gc))
     if (length(ids) == 0 || !i %in% x@compareClusterResult$ID)

--- a/R/accessor.R
+++ b/R/accessor.R
@@ -22,7 +22,10 @@ as.data.frame.groupGOResult <- function(x, ...) {
 ##' @method [[ compareClusterResult
 ##' @export
 `[[.compareClusterResult` <- function(x, i) {
-    gc <- DOSE::geneInCategory2(x)
+    # gc <- DOSE::geneInCategory2(x)
+    gc <- setNames(strsplit(geneID(x), "/", fixed=TRUE),
+        paste(x@compareClusterResult$Cluster,
+            x@compareClusterResult$ID, sep= "-"))
     ids <- grep(i, names(gc))
     # if (!i %in% names(gc))
     if (length(ids) == 0 || !i %in% x@compareClusterResult$ID)

--- a/R/accessor.R
+++ b/R/accessor.R
@@ -10,7 +10,7 @@ as.data.frame.groupGOResult <- function(x, ...) {
 
 ##' @method [ compareClusterResult
 ##' @export
-`[.compareClusterResult` <- function(x, i, j, asis, ...) {
+`[.compareClusterResult` <- function(x, i, j, asis = FALSE, ...) {
     result <- as.data.frame(x)
     y <- result[i,j, ...]
     if (!asis)
@@ -23,9 +23,12 @@ as.data.frame.groupGOResult <- function(x, ...) {
 ##' @export
 `[[.compareClusterResult` <- function(x, i) {
     gc <- geneInCategory(x)
-    if (!i %in% names(gc))
+    ids <- grep(i, names(gc))
+    # if (!i %in% names(gc))
+    if (length(ids) == 0)
         stop("input term not found...")
-    gc[[i]]
+    setNames(sapply(ids, function(x) return(gc[[x]])),
+        x@compareClusterResult$Cluster[ids])
 }
 
 

--- a/R/accessor.R
+++ b/R/accessor.R
@@ -25,7 +25,7 @@ as.data.frame.groupGOResult <- function(x, ...) {
     gc <- geneInCategory(x)
     ids <- grep(i, names(gc))
     # if (!i %in% names(gc))
-    if (length(ids) == 0)
+    if (length(ids) == 0 || !i %in% x@compareClusterResult$ID)
         stop("input term not found...")
     setNames(sapply(ids, function(x) return(gc[[x]])),
         x@compareClusterResult$Cluster[ids])


### PR DESCRIPTION
1、之前`[.compareClusterResult`没有给asis默认值，这样用户如果要使用它就必须要多写一个参数。这次给它加上了默认值。
2、由于geneInCategory的更改，`[[.compareClusterResult`这次也跟着做了一些改变，这样遇到重复的terms，如xx[["hsa04110"]]，就可以将匹配到的全部输出。