### PR TITLE
update `simplify` function to support `ont = ALL`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clusterProfiler
 Type: Package
 Title: A universal enrichment tool for interpreting omics data
-Version: 4.1.4
+Version: 4.1.4.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# clusterProfiler 4.1.4.991
+
++ update `simplify` function to support `ont = ALL` (2021-10-27, Wed)
+
 # clusterProfiler 4.1.4
 
 + import `yulab.utils` (2021-08-20, Fri)

--- a/man/get_wp_organisms.Rd
+++ b/man/get_wp_organisms.Rd
@@ -13,7 +13,7 @@ supported organism list
 list supported organism of WikiPathways
 }
 \details{
-This function extracts information from 'http://data.wikipathways.org/current/gmt/'
+This function extracts information from 'https://data.wikipathways.org/current/gmt/'
 and lists all supported organisms
 }
 \author{


### PR DESCRIPTION
update `simplify` function to support `ont = ALL` for `enrichResult`, `gseaResult` and `compareClusterResult`
[simplify.pdf](https://github.com/YuLab-SMU/clusterProfiler/files/7426737/simplify.pdf)
