### PR TITLE
make simplify work for gseGO compareClusterResult

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),
     person(given = "Erqiang",     family = "Hu",        email = "13766876214@163.com",       role = "ctb"),
     person(given = "Meijun",      family = "Chen",      email = "mjchen1996@outlook.com",    role  = "ctb"),
-    person(given = "Giovanni",    family = "Dall'Olio", email = "giovanni.dallolio@upf.edu", role = "ctb")
+    person(given = "Giovanni",    family = "Dall'Olio", email = "giovanni.dallolio@upf.edu", role = "ctb"),
+    person(given = "Wanqian",     family = "Wei",       email = "altair_wei@outlook.com",    role = "ctb")
 		)
 Maintainer: Guangchuang Yu <guangchuangyu@gmail.com>
 Description: This package supports functional characteristics of both coding and non-coding genomics data for thousands of species with up-to-date gene annotation. It provides a univeral interface for gene functional annotation from a variety of sources and thus can be applied in diverse scenarios. It provides a tidy interface to access, manipulate, and visualize enrichment results to help users achieve efficient data interpretation. Datasets obtained from multiple treatments and time points can be analyzed and compared in a single run, easily revealing functional consensus and differences among distinct conditions.

--- a/R/go-utilities.R
+++ b/R/go-utilities.R
@@ -158,7 +158,7 @@ add_GO_Ontology <- function(obj, GO_DATA) {
 
 get_go_ontology <- function(x) {
     if (is(x, "compareClusterResult")) {
-        if (x@fun != "enrichGO" && x@fun != "groupGO") {
+        if (x@fun != "enrichGO" && x@fun != "groupGO" && x@fun != "gseGO") {
             stop("simplify only work for GO...")
         }
         ont <- x@.call$ont


### PR DESCRIPTION
我注意到 #410 通过简单地更改条件判断来实现 `compareCluster` 对 GESA 的支持，因此我认为 `compareClusterResult` 对 ORA 和 GSEA 来说 API 是一致的。但目前通过 `gseGO` 获得的 `compareClusterResult` 不能通过 `simplify()` 来简化 GO 结果，于是我在这个 PR 中简单的修改了 `get_go_ontology()` 函数中的条件判断，以实现该功能。