### PR TITLE
make sense message in `kegg_rest()`

### DIFF
--- a/R/kegg-utilities.R
+++ b/R/kegg-utilities.R
@@ -113,7 +113,7 @@ get_kegg_species <- function(save = FALSE) {
 
 ##' @importFrom downloader download
 kegg_rest <- function(rest_url) {
-    message("Reading KEGG annotation online:\n" )
+    message('Reading KEGG annotation online: "', rest_url, '"...')
     f <- tempfile()
     
     dl <- mydownload(rest_url, destfile = f)


### PR DESCRIPTION
Just add information to a non-sense message.

Besides, I recommend to alter the function of `kegg_rest()` to only get the content of REST API responses, and then process the retrieved data in downstream functions. Because when the `rest_url = "https://rest.kegg.jp/info/pathway/"` this function will fail in content process but it is reasonable to expect not.