### PR TITLE
update KEGG API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clusterProfiler
 Type: Package
 Title: A universal enrichment tool for interpreting omics data
-Version: 4.7.0
+Version: 4.7.0.991
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clusterProfiler
 Type: Package
 Title: A universal enrichment tool for interpreting omics data
-Version: 4.7.0.991
+Version: 4.7.1
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@ TODO:
 
 
 -->
+# clusterProfiler 4.7.0.991
++ update KEGG api (2023-03-01, Wed)
 
 # clusterProfiler 4.5.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,13 @@ TODO:
 
 
 -->
-# clusterProfiler 4.7.0.991
-+ update KEGG api (2023-03-01, Wed)
+# clusterProfiler 4.7.1
+
++ update according to the KEGG api changes (2023-03-01, Wed)
+
+# clusterProfiler 4.6.0
+
++ Bioconductor 3.16 release 
 
 # clusterProfiler 4.5.3
 

--- a/R/enrichKEGG.R
+++ b/R/enrichKEGG.R
@@ -176,8 +176,8 @@ download.KEGG.Path <- function(species) {
     keggpathid2extid.df[,1] %<>% gsub("[^:]+:", "", .)
     keggpathid2extid.df[,2] %<>% gsub("[^:]+:", "", .)
 
-    keggpathid2name.df <- kegg_list("pathway")
-    keggpathid2name.df[,1] %<>% gsub("path:map", species, .)
+    keggpathid2name.df <- kegg_list("pathway", species)
+    # keggpathid2name.df[,1] %<>% gsub("path:map", species, .)
 
     ## if 'species="ko"', ko and map path are duplicated, only keep ko path.
     ##
@@ -204,7 +204,8 @@ download.KEGG.Module <- function(species) {
     keggmodule2extid.df[,2] %<>% gsub("[^:]+:", "", .)
 
     keggmodule2name.df <- kegg_list("module")
-    keggmodule2name.df[,1] %<>% gsub("md:", "", .)
+    # now module do not nedd sub 'md:'
+    # keggmodule2name.df[,1] %<>% gsub("md:", "", .)
     return(list(KEGGPATHID2EXTID=keggmodule2extid.df,
                 KEGGPATHID2NAME =keggmodule2name.df))
 }

--- a/R/gson.R
+++ b/R/gson.R
@@ -143,7 +143,7 @@ gson_KEGG_mapper = function(file,
   }
   
   if (type == "pathway"){
-    all_pathway = kegg_list("pathway")
+    all_pathway = kegg_list("pathway", species)
     colnames(all_pathway) = c("pathway","pathway_name")
     all_pathway %<>%
       dplyr::mutate_at(.vars = "pathway", .funs = "remove_db_prefix")

--- a/R/kegg-utilities.R
+++ b/R/kegg-utilities.R
@@ -140,8 +140,14 @@ kegg_link <- function(target_db, source_db) {
 }
 
 
-kegg_list <- function(db) {
-    url <- paste0("https://rest.kegg.jp/list/", db, collapse="")
+kegg_list <- function(db, species = NULL) {
+    if (db == "pathway") {
+        url <- paste("https://rest.kegg.jp/list", db, species, sep="/")
+    } else {
+        ## module do not need species
+        url <- paste("https://rest.kegg.jp/list", db, sep="/")
+    }
+    
     kegg_rest(url)
 }
 


### PR DESCRIPTION
Fix #539 
老师，我这次提交修改了kEGG pathway的API url
```r
kegg_list <- function(db, species = NULL) {
    if (db == "pathway") {
        url <- paste("https://rest.kegg.jp/list", db, species, sep="/")
    } else {
        ## module do not need species
        url <- paste("https://rest.kegg.jp/list", db, sep="/")
    }
    
    kegg_rest(url)
}
```
在KEGG的内容更新后，原有的keggmodule2name.df[,1] %<>% gsub("md:", "", .)等语句便不再需要了，我这次将它们注释掉了。
现在KEGG的download to gson file 和 enrichment 均可以正常使用。
Example:
[test_KEGG.pdf](https://github.com/YuLab-SMU/clusterProfiler/files/10857286/test_KEGG.pdf)
