### PR TITLE
Update function to creat KEGG.db 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clusterProfiler
 Type: Package
 Title: A universal enrichment tool for interpreting omics data
-Version: 4.7.1.001
+Version: 4.7.1.002
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,9 @@ TODO:
 
 
 -->
-# clusterProfiler 4.7.1.001
+# clusterProfiler 4.7.1.002
 
++ update `get_data_from_KEGG_db()` for the KEGG api changes (2023-03-05, Sun)
 + removing species info at the end of KEGG pathway names (2023-03-05, Sun)
  
 # clusterProfiler 4.7.1

--- a/R/enrichKEGG.R
+++ b/R/enrichKEGG.R
@@ -287,7 +287,7 @@ get_data_from_KEGG_db <- function(species) {
     PATHID2EXTID.df <- stack(PATHID2EXTID)
     PATHID2EXTID.df <- PATHID2EXTID.df[, c(2,1)]
     PATHID2NAME <- as.list(get_KEGG_db("KEGGPATHID2NAME"))
-    PATHID2NAME.df <- data.frame(path=paste0(species, names(PATHID2NAME)),
+    PATHID2NAME.df <- data.frame(path=names(PATHID2NAME),
                                  name=unlist(PATHID2NAME))
     build_Anno(PATHID2EXTID.df, PATHID2NAME.df)
 }


### PR DESCRIPTION
Fix https://github.com/YuLab-SMU/clusterProfiler/issues/551
KEGG api修改后， createKEGGdb也需要做响应的修改。
```r
> library(createKEGGdb)
> species <-c("hsa","mmu","rno")
> create_kegg_db(species)
> install.packages("./KEGG.db_1.0.tar.gz", repos=NULL,type="source")
> library(KEGG.db)
> library(clusterProfiler)
> data(geneList, package="DOSE")
> gene <- names(geneList)[abs(geneList) > 2]
> kk <- enrichKEGG(gene = gene,
+ organism = 'hsa',
+ pvalueCutoff = 0.05,
+ qvalueCutoff = 0.05,
+ use_internal_data =T)
> nrow(kk)
[1] 9
> head(kk)
               ID                                                   Description GeneRatio  BgRatio       pvalue     p.adjust       qvalue                                             geneID Count
hsa04110 hsa04110                                                    Cell cycle     11/94 127/8275 1.689644e-07 3.531357e-05 3.450432e-05 8318/991/9133/890/983/4085/7272/1111/891/4174/9232    11
hsa04114 hsa04114                                                Oocyte meiosis     10/94 131/8275 2.051606e-06 2.143928e-04 2.094797e-04    991/9133/983/4085/51806/6790/891/9232/3708/5241    10
hsa04218 hsa04218                                           Cellular senescence     10/94 156/8275 9.875269e-06 6.879771e-04 6.722113e-04     2305/4605/9133/890/983/51806/1111/891/776/3708    10
hsa04061 hsa04061 Viral protein interaction with cytokine and cytokine receptor      8/94 100/8275 1.622516e-05 8.477647e-04 8.283372e-04           3627/10563/6373/4283/6362/6355/9547/1524     8
hsa03320 hsa03320                                        PPAR signaling pathway      7/94  75/8275 2.061911e-05 8.618789e-04 8.421279e-04                 4312/9415/9370/5105/2167/3158/5346     7
hsa04914 hsa04914                       Progesterone-mediated oocyte maturation      7/94 102/8275 1.496049e-04 5.211236e-03 5.091815e-03                    9133/890/983/4085/6790/891/5241     7

```