### PR TITLE
Change Wikipathway link

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clusterProfiler
 Type: Package
 Title: A universal enrichment tool for interpreting omics data
-Version: 4.7.1.002
+Version: 4.7.1.003
 Authors@R: c(
     person(given = "Guangchuang", family = "Yu",        email = "guangchuangyu@gmail.com",   role  = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")),
     person(given = "Li-Gen",      family = "Wang",      email = "reeganwang020@gmail.com",   role  = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,9 @@ TODO:
 
 
 -->
-# clusterProfiler 4.7.1.002
+# clusterProfiler 4.7.1.003
 
++ change wikiPathways link. (2023-03-10, Fri)
 + update `get_data_from_KEGG_db()` for the KEGG api changes (2023-03-05, Sun)
 + removing species info at the end of KEGG pathway names (2023-03-05, Sun)
  

--- a/R/enrichKEGG.R
+++ b/R/enrichKEGG.R
@@ -5,7 +5,7 @@
 ##'
 ##' @param gene a vector of entrez gene id.
 ##' @param organism supported organism listed in 'https://www.genome.jp/kegg/catalog/org_list.html'
-##' @param keyType one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'
+##' @param keyType one of "kegg", 'ncbi-geneid', 'ncbi-proteinid' and 'uniprot'
 ##' @param minGSSize minimal size of genes annotated by Ontology term for testing.
 ##' @param maxGSSize maximal size of genes annotated for testing
 ##' @inheritParams enricher

--- a/R/wikiPathways.R
+++ b/R/wikiPathways.R
@@ -62,7 +62,7 @@ prepare_WP_data <- function(organism) {
 }
 
 get_wp_gmtfile <- function() {
-    wpurl <- 'https://data.wikipathways.org/current/gmt/'
+    wpurl <- 'https://wikipathways-data.wmcloud.org/current/gmt/'
     x <- readLines(wpurl)
     y <- x[grep('\\.gmt',x)]
     sub(".*(wikipathways-.*\\.gmt).*", "\\1",  y[grep('File', y)])
@@ -71,7 +71,7 @@ get_wp_gmtfile <- function() {
 
 ##' list supported organism of WikiPathways
 ##'
-##' This function extracts information from 'https://data.wikipathways.org/current/gmt/'
+##' This function extracts information from 'https://wikipathways-data.wmcloud.org/current/gmt/'
 ##' and lists all supported organisms
 ##' @title get_wp_organism
 ##' @return supported organism list
@@ -87,7 +87,7 @@ get_wp_organisms <- function() {
 get_wp_data <- function(organism, output = "data.frame") {
     organism <- sub(" ", "_", organism)
     gmtfile <- get_wp_gmtfile()
-    wpurl <- 'https://data.wikipathways.org/current/gmt/'
+    wpurl <- 'https://wikipathways-data.wmcloud.org/current/gmt/'
     url <- paste0(wpurl,
                   gmtfile[grep(organism, gmtfile)])
     f <- tempfile(fileext = ".gmt")

--- a/man/enrichKEGG.Rd
+++ b/man/enrichKEGG.Rd
@@ -24,7 +24,7 @@ enrichKEGG(
 
 \item{organism}{supported organism listed in 'https://www.genome.jp/kegg/catalog/org_list.html'}
 
-\item{keyType}{one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'}
+\item{keyType}{one of "kegg", 'ncbi-geneid', 'ncbi-proteinid' and 'uniprot'}
 
 \item{pvalueCutoff}{adjusted pvalue cutoff on enrichment tests to report}
 

--- a/man/enrichMKEGG.Rd
+++ b/man/enrichMKEGG.Rd
@@ -23,7 +23,7 @@ enrichMKEGG(
 
 \item{organism}{supported organism listed in 'https://www.genome.jp/kegg/catalog/org_list.html'}
 
-\item{keyType}{one of "kegg", 'ncbi-geneid', 'ncib-proteinid' and 'uniprot'}
+\item{keyType}{one of "kegg", 'ncbi-geneid', 'ncbi-proteinid' and 'uniprot'}
 
 \item{pvalueCutoff}{adjusted pvalue cutoff on enrichment tests to report}
 

--- a/man/get_wp_organisms.Rd
+++ b/man/get_wp_organisms.Rd
@@ -13,7 +13,7 @@ supported organism list
 list supported organism of WikiPathways
 }
 \details{
-This function extracts information from 'https://data.wikipathways.org/current/gmt/'
+This function extracts information from 'https://wikipathways-data.wmcloud.org/current/gmt/'
 and lists all supported organisms
 }
 \author{


### PR DESCRIPTION
1. Fix #547 
Change the typo ncib-proteinid ==> ncbi-proteinid
2. Fix #559 
Wikipathway 的url已经改变，需要进行修改。 不过之前的版本也是可用的，因为wikipathways的网站设置了自动跳转功能。