### PR TITLE
trim KEGG pathway name tail like "- Mus musculus (house mouse)"

### DIFF
--- a/R/enrichKEGG.R
+++ b/R/enrichKEGG.R
@@ -186,7 +186,7 @@ download.KEGG.Path <- function(species) {
 
     keggpathid2name.df <- kegg_list("pathway", species)
 
-    keggpathid2name.df[,2] <- sub("\\s-\\s[a-zA-Z ]+\\(\\w+\\)$", "", keggpathid2name.df[,2])
+    keggpathid2name.df[,2] <- sub("\\s-\\s[a-zA-Z ]+\\([a-zA-Z ]+\\)$", "", keggpathid2name.df[,2])
     # keggpathid2name.df[,1] %<>% gsub("path:map", species, .)
 
     ## if 'species="ko"', ko and map path are duplicated, only keep ko path.


### PR DESCRIPTION
How about the changes?

`git diff enrichKEGG.R`

```
-    keggpathid2name.df[,2] <- sub("\\s-\\s[a-zA-Z ]+\\(\\w+\\)$", "", keggpathid2name.df[,2])
+    keggpathid2name.df[,2] <- sub("\\s-\\s[a-zA-Z ]+\\([a-zA-Z ]+\\)$", "", keggpathid2name.df[,2])
```

The old regular pattern can only match the tail like: 

> hsa00630	Glyoxylate and dicarboxylate metabolism - Homo sapiens (human)

NOTE：only one word in the ()

The new regular pattern can also match the tail like:

> mmu00630	Glyoxylate and dicarboxylate metabolism - Mus musculus (house mouse)

NOTE：multiple words in the ()